### PR TITLE
Added queue for next run operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,11 +154,6 @@ class MMST extends EventEmitter {
         const connection = await this._connect(peer)
         connected = true
         this.addConnection(peer, connection)
-
-        // Listen on the connection close to invoke `run` again
-        connection.once('close', () => {
-          this.queue.add(() => this.run())
-        })
         break
       } catch (e) {
         // Oh well

--- a/index.js
+++ b/index.js
@@ -47,6 +47,9 @@ class MMST extends EventEmitter {
     // How long to lookup peers fore before giving up and using what you have
     lookupTimeout = DEFAULT_LOOKUP_TIMEOUT,
 
+    // How long to wait for `run` to be finished
+    queueTimeout = lookupTimeout + (2 * 1000),
+
   }) {
     super()
     this.id = id
@@ -55,10 +58,15 @@ class MMST extends EventEmitter {
     this.sampleSize = sampleSize
     this.percentFar = percentFar
     this.maxPeers = maxPeers
+
+    if (lookupTimeout > queueTimeout) {
+      throw new Error('queueTimeout must be higher than lookupTimeout')
+    }
+
     this.lookupTimeout = lookupTimeout
     this.queue = new PQueue({
       concurrency: 1,
-      timeout: lookupTimeout + (2 * 1000)
+      timeout: queueTimeout
     })
 
     this.connectedPeers = new Set()

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ class MMST extends EventEmitter {
         this.hasConnectedFar = true
 
         // Listen on connection close and set `hasConnectedFar` false
-        connection.once('end', () => {
+        connection.once('close', () => {
           this.hasConnectedFar = false
         })
         break

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "delay": "^4.3.0",
     "end-of-stream-promise": "^1.0.0",
+    "p-queue": "^6.3.0",
     "promise-defer": "^1.0.0",
     "randomize-array": "^1.2.0",
     "xor-distance": "^2.0.0"


### PR DESCRIPTION
Hey @RangerMauve how are you?

This PR adds a queue for async operations in order to wait every run to be done. This could be helpful to not overlapping the same operation when you have multiple disconnections (where every close will execute `run` again)